### PR TITLE
Moddates and tagdirs

### DIFF
--- a/simplenote-backup.py
+++ b/simplenote-backup.py
@@ -13,7 +13,20 @@ api = SimperiumApi(appname, token)
 #print token
 notes = api.note.index(data=True)
 for note in notes['index']:
-    path = os.path.join(backup_dir, note['id'] + '.txt')
+    #if the note has a single tag, put it into a subdirectory named as the tag
+    if len(note['d']['tags'])==1:
+        tag = note['d']['tags'][0]
+    else:
+        tag = ''
+    dir_path = os.path.join(backup_dir, tag)
+    try:
+        os.makedirs(dir_path)
+    except OSError as e:
+        if e.errno == 17:
+            # the subdir already exists
+            pass
+
+    path = os.path.join(dir_path, note['id'] + '.txt')
     #print path
     with open(path, "w") as f:
         # print json.dumps(note, indent=2)

--- a/simplenote-backup.py
+++ b/simplenote-backup.py
@@ -21,5 +21,6 @@ for note in notes['index']:
         f.write(note['d']['content'].encode('utf8'))
         f.write("\n")
         f.write("Tags: %s\n" % ", ".join(note['d']['tags']).encode('utf8'))
+    os.utime(path,(note['d']['modificationDate'],note['d']['modificationDate']))
 
 print "Done: %d files." % len(notes['index'])

--- a/simplenote-backup.py
+++ b/simplenote-backup.py
@@ -13,12 +13,17 @@ api = SimperiumApi(appname, token)
 #print token
 notes = api.note.index(data=True)
 for note in notes['index']:
+trashed = 0
+    dir_path = backup_dir
+    #if the note was trashed, put it into a 'TRASH' subdirectory
+    if note['d']['deleted']== True:
+        dir_path = os.path.join(dir_path, 'TRASH')
+        trashed = trashed + 1
+
     #if the note has a single tag, put it into a subdirectory named as the tag
     if len(note['d']['tags'])==1:
-        tag = note['d']['tags'][0]
-    else:
-        tag = ''
-    dir_path = os.path.join(backup_dir, tag)
+        dir_path = os.path.join(dir_path, note['d']['tags'][0])
+
     try:
         os.makedirs(dir_path)
     except OSError as e:
@@ -34,6 +39,9 @@ for note in notes['index']:
         f.write(note['d']['content'].encode('utf8'))
         f.write("\n")
         f.write("Tags: %s\n" % ", ".join(note['d']['tags']).encode('utf8'))
+        # record pinned notes and whatever else
+        if len(note['d']['systemTags'])>0:
+            f.write("System tags: %s\n" % ", ".join(note['d']['systemTags']).encode('utf8'))
     os.utime(path,(note['d']['modificationDate'],note['d']['modificationDate']))
 
-print "Done: %d files." % len(notes['index'])
+print "Done: %d files (%d in TRASH)." % (len(index), trashed)

--- a/simplenote-backup.py
+++ b/simplenote-backup.py
@@ -15,10 +15,11 @@ notes = api.note.index(data=True)
 for note in notes['index']:
     path = os.path.join(backup_dir, note['id'] + '.txt')
     #print path
-    f = open(path, "w")
-    # print json.dumps(note, indent=2)
-    f.write("id: %s\n" % note['id'])
-    f.write("tags: %s\n" % ", ".join(note['d']['tags']).encode('utf8'))
-    f.write("\n")
-    f.write(note['d']['content'].encode('utf8'))
+    with open(path, "w") as f:
+        # print json.dumps(note, indent=2)
+        #f.write("id: %s\n" % note['id'])
+        f.write(note['d']['content'].encode('utf8'))
+        f.write("\n")
+        f.write("Tags: %s\n" % ", ".join(note['d']['tags']).encode('utf8'))
+
 print "Done: %d files." % len(notes['index'])

--- a/simplenote-backup.py
+++ b/simplenote-backup.py
@@ -11,9 +11,17 @@ if not os.path.exists(backup_dir):
 
 api = SimperiumApi(appname, token)
 #print token
-notes = api.note.index(data=True)
-for note in notes['index']:
+
+dump = api.note.index(data=True)
+index = dump['index']
+# the dump might be paged; go through all the pages
+while 'mark' in dump:
+    dump = api.note.index(data=True, mark=dump['mark'])
+    json.dump(dump,open("dump", "a"))
+    index = index + dump['index']
+
 trashed = 0
+for note in index:
     dir_path = backup_dir
     #if the note was trashed, put it into a 'TRASH' subdirectory
     if note['d']['deleted']== True:


### PR DESCRIPTION
Remove the "Id:" line and move the "Tags:" line to the end of the note, so the text looks the same as when it was in Simplenote.

Set the modification dates of the files to the modification date of the note.

If the note has a single tag, create it into a directory named as the tag.

With these changes, importing the notes into macos' Notes.app creates a reasonably similar experience to that of Simplenote.
