### PR TITLE
Stop writing to "dump" file, which is never used again

### DIFF
--- a/simplenote-backup.py
+++ b/simplenote-backup.py
@@ -17,7 +17,6 @@ index = dump['index']
 # the dump might be paged; go through all the pages
 while 'mark' in dump:
     dump = api.note.index(data=True, mark=dump['mark'])
-    json.dump(dump,open("dump", "a"))
     index = index + dump['index']
 
 trashed = 0


### PR DESCRIPTION
File is created at the beginning, but never used again.

Also, it's left behind after running, which could go unnoticed by user maybe containing sensible data.