### PR TITLE
Add Docker building and running.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN \
+  apt-get update && \
+  apt-get install -y make \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+RUN pip install --no-cache \
+    git+https://github.com/Simperium/simperium-python.git
+
+COPY . /usr/src/simplenote-backup/
+WORKDIR /usr/src/simplenote-backup/
+
+CMD [ "make" ]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ If you wish to execute a backup job once an hour, add the following line to your
 
     0 * * * * cd $HOME/SimplenoteBackup/simplenote-backup && make TOKEN=YOU_TOKEN_HERE > cron.log 2>&1
 
+## Build and run without Python using Docker
+
+    # Build a local Docker image straight from sources on Github.
+    docker build --pull -t simplenote-backup github.com/hiroshi/simplenote-backup
+    
+    # Create host's backup dir. Otherwise, Docker will create it, but with wrong ownership (root:root).
+    mkdir -vp /path/to/backups/
+    
+    # Launch a one-off container which will dump files in your specified path, mounted at container's /data/ directory.
+    docker run --rm -it --user $(id -u):$(id -g) -e BACKUP_DIR=/data/ -e TOKEN=your_token -v /path/to/backups/:/data/ simplenote-backup
 
 ## TODO
 - Provide an archive file packed with simperium sdk.


### PR DESCRIPTION
Adds an easy method for building and running without installing anything else but Docker. No need to clone, nor installing any deps, since everything is included in the build.

You can test the build using my fork's repo URL. That's how I'm now backing up my notes now. Thanks for such a useful tool!

Might come handy to enable running as a service, as in the readme 'TODO' section. Ditto for development, without needing to install anything.

Requires #6, otherwise it fails because of write permissions.